### PR TITLE
Rectifying %>% with dplyr

### DIFF
--- a/R/file.R
+++ b/R/file.R
@@ -35,8 +35,8 @@
 }
 
 ### send to file
-`%>%`   <- function( object, file) ..redirect(object,file,type="output" , append=FALSE)
-`%>>%`  <- function( object, file) ..redirect(object,file,type="output" , append=TRUE )
+`%file>%`   <- function( object, file) ..redirect(object,file,type="output" , append=FALSE)
+`%file>>%`  <- function( object, file) ..redirect(object,file,type="output" , append=TRUE )
 `%2>>%` <- function( object, file) ..redirect(object,file,type="message", append=TRUE )
 `%2>%`  <- function( object, file) ..redirect(object,file,type="message", append=FALSE)
 `%*>>%` <- function( object, file) ..redirect(object,file,type="both", append=TRUE )  

--- a/man/files.Rd
+++ b/man/files.Rd
@@ -1,8 +1,8 @@
 \name{files}
 \alias{\%<<\%}
 \alias{\%<\%}
-\alias{\%>>\%}
-\alias{\%>\%}
+\alias{\%fie>>\%}
+\alias{\%file>\%}
 
 \alias{\%<<2\%}
 \alias{\%<2\%}
@@ -42,11 +42,11 @@
   NULL, used for the side effects.
 }
 \details{
-  \code{\%>\%} sends the \code{object} to the \code{file}. The object is printed to the file 
+  \code{\%file>\%} sends the \code{object} to the \code{file}. The object is printed to the file 
   according to the function specified in the \code{operators.print} option supplied with this package, 
   most likely to be the \code{\link{print}} function. See examples.
   
-  \code{\%>>\%} appends the output to the file.
+  \code{\%file>>\%} appends the output to the file.
   
   \code{\%2>\%} sends the message stream to the file by \code{\link{sink}}ing the 
   \code{message} stream to the file. See \code{\link{sink}} for details. 


### PR DESCRIPTION
Changed %>% and %>>% to %file>% and %file>>% to fix issues with dplyr
package